### PR TITLE
CAN Update

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -43,7 +43,7 @@ public class Robot extends TimedRobot {
     limelight = new Limelight();
 
     OI.init();
-    
+
     chooser.setDefaultOption("Default Auto", new SimpleAuton());
     chooser.addOption("Test Auto", new SimpleAuton());
     chooser.addOption("Cha Cha Slide", new ChaChaSlide());
@@ -73,6 +73,7 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void disabledInit() {
+    drivetrain.setCoast();
   }
 
   @Override
@@ -94,14 +95,8 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void autonomousInit() {
+    drivetrain.setBrake();
     autonomousCommand = chooser.getSelected();
-
-    /*
-     * String autoSelected = SmartDashboard.getString("Auto Selector", "Default");
-     * switch(autoSelected) { case "My Auto": autonomousCommand = new
-     * MyAutoCommand(); break; case "Default Auto": default: autonomousCommand = new
-     * ExampleCommand(); break; }
-     */
 
     // schedule the autonomous command (example)
     if (autonomousCommand != null) {
@@ -126,6 +121,7 @@ public class Robot extends TimedRobot {
     if (autonomousCommand != null) {
       autonomousCommand.cancel();
     }
+    drivetrain.setBrake();
   }
 
   /**

--- a/src/main/java/frc/robot/RobotMap.java
+++ b/src/main/java/frc/robot/RobotMap.java
@@ -15,10 +15,10 @@ package frc.robot;
  */
 public class RobotMap {
   // motors 
-  public static final byte FRONT_LEFT_MOTOR = 9;
-  public static final byte FRONT_RIGHT_MOTOR = 7;
-  public static final byte BACK_LEFT_MOTOR = 8;
-  public static final byte BACK_RIGHT_MOTOR = 6;
+  public static final byte FRONT_LEFT_MOTOR = 0;
+  public static final byte FRONT_RIGHT_MOTOR = 1;
+  public static final byte BACK_LEFT_MOTOR = 2;
+  public static final byte BACK_RIGHT_MOTOR = 3;
 
   // input
   public static final byte JOY_PORT = 0;

--- a/src/main/java/frc/robot/commands/autoncommands/SimpleAuton.java
+++ b/src/main/java/frc/robot/commands/autoncommands/SimpleAuton.java
@@ -19,11 +19,11 @@ public class SimpleAuton extends CommandGroup {
   public SimpleAuton() {
     // Add Commands here:
     addSequential(new DriveStraight(2, 0.2, Drive.FORWARD));
-    addSequential(new WaitCommand(0.5));
+    //addSequential(new WaitCommand(0.5)); delay no longer needed
     addSequential(new RotateBot(90, Rotate.COUNTER_CLOCKWISE));
-    addSequential(new WaitCommand(0.5));
+    //addSequential(new WaitCommand(0.5));
     addSequential(new DriveStraight(2, 0.3, Drive.RIGHT));
-    addSequential(new WaitCommand(0.5));
+    //addSequential(new WaitCommand(0.5));
     addSequential(new RotateBot(90, Rotate.CLOCKWISE));
 
     // e.g. addSequential(new Command1());

--- a/src/main/java/frc/robot/commands/autoncommands/SimpleAuton.java
+++ b/src/main/java/frc/robot/commands/autoncommands/SimpleAuton.java
@@ -8,7 +8,6 @@
 package frc.robot.commands.autoncommands;
 
 import edu.wpi.first.wpilibj.command.CommandGroup;
-import edu.wpi.first.wpilibj.command.WaitCommand;
 import frc.robot.commands.autoncommands.DriveStraight.Drive;
 import frc.robot.commands.autoncommands.RotateBot.Rotate;;
 
@@ -19,11 +18,8 @@ public class SimpleAuton extends CommandGroup {
   public SimpleAuton() {
     // Add Commands here:
     addSequential(new DriveStraight(2, 0.2, Drive.FORWARD));
-    //addSequential(new WaitCommand(0.5)); delay no longer needed
     addSequential(new RotateBot(90, Rotate.COUNTER_CLOCKWISE));
-    //addSequential(new WaitCommand(0.5));
     addSequential(new DriveStraight(2, 0.3, Drive.RIGHT));
-    //addSequential(new WaitCommand(0.5));
     addSequential(new RotateBot(90, Rotate.CLOCKWISE));
 
     // e.g. addSequential(new Command1());

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -19,15 +19,15 @@ import frc.robot.commands.MecanumDriveWithStick.Orientation;
  * Add your docs here.
  */
 public class Drivetrain extends Subsystem {
-  private static PWMVictorSPX frontLeftMotor, frontRightMotor, backLeftMotor, backRightMotor;
+  private static WPI_VictorSPX frontLeftMotor, frontRightMotor, backLeftMotor, backRightMotor;
   private static MecanumDrive rodot;
   private static ADXRS450_Gyro gyro;
 
   public Drivetrain() {
-    frontLeftMotor = new PWMVictorSPX(RobotMap.FRONT_LEFT_MOTOR);
-    frontRightMotor = new PWMVictorSPX(RobotMap.FRONT_RIGHT_MOTOR);
-    backLeftMotor = new PWMVictorSPX(RobotMap.BACK_LEFT_MOTOR);
-    backRightMotor = new PWMVictorSPX(RobotMap.BACK_RIGHT_MOTOR);
+    frontLeftMotor = new WPI_VictorSPX(RobotMap.FRONT_LEFT_MOTOR);
+    frontRightMotor = new WPI_VictorSPX(RobotMap.FRONT_RIGHT_MOTOR);
+    backLeftMotor = new WPI_VictorSPX(RobotMap.BACK_LEFT_MOTOR);
+    backRightMotor = new WPI_VictorSPX(RobotMap.BACK_RIGHT_MOTOR);
 
     rodot = new MecanumDrive(frontLeftMotor, backLeftMotor, frontRightMotor, backRightMotor);
 

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -7,8 +7,10 @@
 
 package frc.robot.subsystems;
 
+import com.ctre.phoenix.motorcontrol.NeutralMode;
+import com.ctre.phoenix.motorcontrol.can.WPI_VictorSPX;
+
 import edu.wpi.first.wpilibj.ADXRS450_Gyro;
-import edu.wpi.first.wpilibj.PWMVictorSPX;
 import edu.wpi.first.wpilibj.command.Subsystem;
 import edu.wpi.first.wpilibj.drive.MecanumDrive;
 import frc.robot.RobotMap;
@@ -51,6 +53,20 @@ public class Drivetrain extends Subsystem {
 
   public void stop() {
     rodot.stopMotor();
+  }
+
+  public void setBrake() {
+    frontLeftMotor.setNeutralMode(NeutralMode.Brake);
+    frontRightMotor.setNeutralMode(NeutralMode.Brake);
+    backLeftMotor.setNeutralMode(NeutralMode.Brake);
+    backRightMotor.setNeutralMode(NeutralMode.Brake);
+  }
+
+  public void setCoast() {
+    frontLeftMotor.setNeutralMode(NeutralMode.Coast);
+    frontRightMotor.setNeutralMode(NeutralMode.Coast);
+    backLeftMotor.setNeutralMode(NeutralMode.Coast);
+    backRightMotor.setNeutralMode(NeutralMode.Coast);
   }
 
   public double getGyroo() {

--- a/vendordeps/Phoenix.json
+++ b/vendordeps/Phoenix.json
@@ -1,0 +1,135 @@
+{
+    "fileName": "Phoenix.json",
+    "name": "CTRE-Phoenix",
+    "version": "5.14.1",
+    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
+    "mavenUrls": [
+        "http://devsite.ctr-electronics.com/maven/release/"
+    ],
+    "jsonUrl": "http://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/Phoenix-latest.json",
+    "javaDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "api-java",
+            "version": "5.14.1"
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "wpiapi-java",
+            "version": "5.14.1"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "cci",
+            "version": "5.14.1",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "canutils",
+            "version": "5.14.1",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "platform-stub",
+            "version": "5.14.1",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "wpiapi-cpp",
+            "version": "5.14.1",
+            "libName": "CTRE_Phoenix_WPI",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "api-cpp",
+            "version": "5.14.1",
+            "libName": "CTRE_Phoenix",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "cci",
+            "version": "5.14.1",
+            "libName": "CTRE_PhoenixCCI",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "canutils",
+            "version": "5.14.1",
+            "libName": "CTRE_PhoenixCanutils",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "platform-stub",
+            "version": "5.14.1",
+            "libName": "CTRE_PhoenixPlatform",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "core",
+            "version": "5.14.1",
+            "libName": "CTRE_PhoenixCore",
+            "headerClassifier": "headers"
+        }
+    ]
+}


### PR DESCRIPTION
The motor controllers are swapped to be able to be used on the CAN network. The changes include changing the motor controller objects in the drivebase, changing the IDs of the motors, and adding brake or coast toggle modes for the motors. CAN over PWM now.